### PR TITLE
Adjust Variable Generation

### DIFF
--- a/plugins/org.modmacao.cm/src/org/modmacao/cm/ansible/VariablesGenerator.mtl
+++ b/plugins/org.modmacao.cm/src/org/modmacao/cm/ansible/VariablesGenerator.mtl
@@ -25,15 +25,16 @@ ipaddresses:
 mixins:
 [for (part : MixinBase | aResource.parts)]
  - name: [part.mixin.name/]
-   [for (as : AttributeState | part.attributes)]
-   [as.name/]: [as.value/]
-   [/for]
+   attributes:
+      [for (as : AttributeState | part.attributes)]
+      [as.name.replaceAll('\\.', '_')/]: [as.value/]
+      [/for]
 [/for]
 [/if]
 [if (aResource.attributes->size() > 0)]
 attributes:
 [for (as : AttributeState | aResource.attributes)]
-  [as.name/]: [as.value/]
+  [as.name.replaceAll('\\.', '_')/]: [as.value/]
 [/for]
 [/if]
 
@@ -62,9 +63,10 @@ links:
       mixins:
       [for (part : MixinBase | link.target.parts)]
         - name: [part.mixin.name/]
-          [for (as : AttributeState | part.attributes)]
-          [as.name/]: [as.value/]
-          [/for]
+          attributes:
+             [for (as : AttributeState | part.attributes)]
+             [as.name.replaceAll('\\.', '_')/]: [as.value/]
+             [/for]
       [/for]
       [/if]
       [if (link.target.kind.term.toString() = 'component')]


### PR DESCRIPTION
**Improved generation of Ansible Variable file:**
- Dots within Attribute Names are replaced with Underscores:
  - Example occi.core -> occi_core
- Improved separation of Attributes within MixinBases:
  - Also allows for attributes with title "name" (Required in TOSCA2OCCI project)
  - Example:

```
Previously:

mixins:
 - name: mongoDB
   dbPort: 3303
 - name: apache
   dbPort: 3122
   name: test

Now:

mixins:
 - name: mongoDB
   attributes:
      dbPort: 3303
 - name: apache
   attributes:
      dbPort: 3122
      name: test
```